### PR TITLE
Fix GraphQL query typo

### DIFF
--- a/src/pyxplora_api/gql_handler.py
+++ b/src/pyxplora_api/gql_handler.py
@@ -58,7 +58,7 @@ class GQLHandler(HandlerGQL):
             Exception: If the query string is empty.
         """
         if query is None:
-            raise HandlerException("GraphQL guery string MUST NOT be empty!")
+            raise HandlerException("GraphQL query string MUST NOT be empty!")
         # Add Xplora® API headers
         requestHeaders = self.getRequestHeaders("application/json; charset=UTF-8")
         # create GQLClient

--- a/src/pyxplora_api/gql_handler_async.py
+++ b/src/pyxplora_api/gql_handler_async.py
@@ -41,7 +41,7 @@ class GQLHandler(HandlerGQL):
         operation_name: str | None = None,
     ) -> dict[str, Any]:
         if query is None:
-            raise HandlerException("GraphQL guery string MUST NOT be empty!")
+            raise HandlerException("GraphQL query string MUST NOT be empty!")
         # Add Xplora® API headers
         requestHeaders = self.getRequestHeaders("application/json; charset=UTF-8")
         # create GQLClient


### PR DESCRIPTION
## Summary
- correct typo in error message in `gql_handler.py`
- correct same typo in async handler

## Testing
- `black --check .` *(fails: would reformat files)*
- `flake8 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684410fe74788325945f2cd130148362