### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.check-tag.outputs.match == 'true'
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: "3.9"
+          python-version: "3.13"
           check-latest: true
       - name: Install dependencies
         if: steps.check-tag.outputs.match == 'true'

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,10 @@ setuptools.setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
@@ -49,5 +50,5 @@ setuptools.setup(
     ],
     keywords="api xplora watch",
     install_requires=requirements_array,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
### Motivation
- Dependabot and CI maintenance require moving away from Python 3.9, so the package minimum and workflows are updated to target supported newer Python versions.

### Description
- Bumped package minimum to `python_requires=">=3.10"` and removed the Python 3.9 classifier while adding classifiers for Python 3.12 and 3.13 in `setup.py`.
- Updated the CI test matrix in `.github/workflows/pythonpackage.yml` to run on `3.10`, `3.11`, `3.12`, and `3.13` instead of including `3.9`.
- Updated release packaging in `.github/workflows/pythonpublish.yml` to build releases using Python `3.13` instead of `3.9`.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues and passed. 
- Ran `python -m black --line-length=127 --check .` which passed with no formatting errors. 
- Ran `python -m compileall .` which succeeded and byte-compiled the package sources. 
- Attempted full dependency install and test (CI-like `pip install` and `pytest`) but the run was blocked by package index `403 Forbidden` errors while fetching build dependencies, and `python -m pytest` collected 0 tests (no tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c499c34483259d682f7bedd9f195)