### PR TITLE
Fix pre-commit PR credential handling

### DIFF
--- a/.github/workflows/a_pre_commit.yml
+++ b/.github/workflows/a_pre_commit.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.TOKEN }}
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
### Motivation
- Disable persisted checkout credentials in the pre-commit workflow so `peter-evans/create-pull-request` can configure its own `token` without creating duplicate `Authorization` headers.

### Description
- Add `persist-credentials: false` to the `actions/checkout` step in `.github/workflows/a_pre_commit.yml`.

### Testing
- Ran `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "workflow YAML parsed successfully"'` which parsed the workflows successfully; attempted a `python` YAML parse via `python - <<'PY' ...` which failed because `PyYAML` is not installed in this environment; and the change was committed (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c8f31d7c832592ad85c950bed101)