### PR TITLE
Bump pre-commit hook revisions and set default Python to 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ ci:
   submodules: false
 
 default_language_version:
-  python: python3.9
+  python: python3.10
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.15
+    rev: v0.15.16
     hooks:
       - id: ruff
         exclude: ^.github|sample|gql_mutations\.py|gql_queries\.py
@@ -23,7 +23,7 @@ repos:
           - --fix
           - --line-length=127
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
+    rev: v2.3.3
     hooks:
       - id: autoflake
         args:
@@ -32,7 +32,7 @@ repos:
           - "--remove-unused-variables"
           - "--remove-all-unused-imports"
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 26.5.1
     hooks:
       - id: black
         args:
@@ -41,7 +41,7 @@ repos:
           - --quiet
         files: ^((src|sample|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -50,7 +50,7 @@ repos:
           - --quiet-level=2
         exclude_types: [csv, json]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-yaml
@@ -83,7 +83,7 @@ repos:
         exclude_types: [json]
         exclude: \.md$
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.6.0
+    rev: v0.8.1
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
@@ -92,18 +92,18 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py39-plus
+          - --py310-plus
           - --force
           - --keep-updates
         files: ^(src|tests|sample)/.+\.py$
         additional_dependencies:
-          - black==24.1.1
+          - black==26.5.1
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
+        args: [--py310-plus, --keep-runtime-typing]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.3
+    rev: v8.30.1
     hooks:
       - id: gitleaks


### PR DESCRIPTION
### Motivation
- Align pre-commit toolchain with current supported runtime by setting `default_language_version` to `python3.10`.
- Keep linters and formatters up-to-date by bumping hook revisions to recent stable releases to benefit from fixes and new checks.

### Description
- Updated `.pre-commit-config.yaml` to set `default_language_version: python3.10`.
- Bumped hook revisions for `ruff`, `autoflake`, `black` (mirror), `codespell`, `pre-commit-hooks`, `python-typing-update`, `pyupgrade`, and `gitleaks` to newer stable releases.
- Adjusted `python-typing-update` and `pyupgrade` arguments to `--py310-plus` and updated the `python-typing-update` additional dependency to `black==26.5.1`.

### Testing
- Validated the YAML structure with `ruby -e "require 'yaml'; data = YAML.load_file('.pre-commit-config.yaml'); abort 'missing repos' unless data.is_a?(Hash) && data['repos'].is_a?(Array); puts 'YAML OK'"` which returned `YAML OK`.
- Ran `git diff --check` which reported no whitespace or merge-marker issues.
- Attempt to run `python -m pre_commit run --all-files` could not be executed because `pre-commit` is not installed in the environment and installing it via `pip` was blocked by a network/tunnel `403 Forbidden` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27d08956388325b341df1e3553c16d)