### PR TITLE
Fix gitleaks pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,9 +104,3 @@ repos:
     rev: v8.30.0
     hooks:
       - id: gitleaks
-        args:
-          - --redact
-          - --no-git
-          - --verbose
-          - --exit-code=1
-          - --config=.gitleaks.toml


### PR DESCRIPTION
### Motivation
- The gitleaks pre-commit hook was configured with custom `args` (including the unsupported `--no-git` flag and a `.gitleaks.toml` reference) which could cause the hook to fail before scanning; switching to the upstream defaults prevents that failure.

### Description
- Removed the custom `args` block from the `gitleaks` entry in `.pre-commit-config.yaml` so the hook uses the upstream `v8.30.0` defaults.

### Testing
- Ran `git diff --check` and a Python assertion that inspects `.pre-commit-config.yaml` to confirm the `gitleaks` hook block contains only `- id: gitleaks` and does not include `--no-git` or a `--config` reference (these checks passed); attempting to install/run `pre-commit` in this environment failed due to network/PyPI access restrictions, so an actual `pre-commit run gitleaks` was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27d3ee3d848325b6b03f9931d888ae)