### PR TITLE
Add Dependabot group for github/codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     labels:
       - "in progress"
       - "dependencies"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: pip
     directory: /


### PR DESCRIPTION
### Motivation
- Group Dependabot updates for the GitHub CodeQL action so related `github/codeql-action*` updates are aggregated instead of creating separate pull requests.

### Description
- Update `/.github/dependabot.yml` to add a `groups` entry under the `github-actions` update configuration with a `codeql-action` group that matches the pattern `github/codeql-action*`.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ef1c0aec8325b5c17c2f657bfd27)